### PR TITLE
time slider (display only for now)

### DIFF
--- a/docroot/s/siren.css
+++ b/docroot/s/siren.css
@@ -98,6 +98,8 @@ body {
 .player .time input {
     display: block;
     width: 80%;
+    margin-left: auto;
+    margin-right: auto;
 }
 
 .nc {

--- a/docroot/s/siren.css
+++ b/docroot/s/siren.css
@@ -95,6 +95,10 @@ body {
     font-size: 120%;
     margin-bottom: 10px;
 }
+.player .time input {
+    display: block;
+    width: 80%;
+}
 
 .nc {
     display: grid;

--- a/elm/Main.elm
+++ b/elm/Main.elm
@@ -199,7 +199,7 @@ update msg model =
         Seek id s ->
             let
                 c = if model.dragging == Just id then
-                        Debug.log ("seek " ++ id ++ " to " ++ toString s) Cmd.none
+                        wsSend model.wsURL <| cmdSeek s
                     else
                         Cmd.none
             in
@@ -287,8 +287,8 @@ viewPlayer model =
                             [ Attr.type_ "range"
                             , Attr.min "0"
                             , Attr.max (toString status.duration)
-                            , Events.on "mousedown" <| Decode.succeed (StartDrag song.id)
-                            , Events.on "change" (Decode.map (Seek song.id) targetValueAsNumber)
+                            , Events.on "mousedown" <| Decode.succeed (StartDrag status.songid)
+                            , Events.on "change" (Decode.map (Seek status.songid) targetValueAsNumber)
                             ] ++ if model.dragging == Nothing then
                                     [ Attr.value (toString realElapsed) ]
                                  else
@@ -561,6 +561,15 @@ pressNext =
 cmdPlaylistAdd : String -> String
 cmdPlaylistAdd id =
     buildWsCmdID "add" id
+
+
+cmdSeek : Float -> String
+cmdSeek seconds =
+    Encode.encode 0 <|
+        Encode.object
+            [ ( "cmd", Encode.string "seek" )
+            , ( "seconds", Encode.float seconds )
+            ]
 
 
 cmdList : String -> String -> String -> String -> String

--- a/elm/Main.elm
+++ b/elm/Main.elm
@@ -217,7 +217,7 @@ update msg model =
         Seek id s ->
             ( { model | seek = Wait s }
             , if model.seek == Drag id then
-                wsSend model.wsURL <| cmdSeek s
+                wsSend model.wsURL <| cmdSeek id s
               else
                 Cmd.none
             )
@@ -589,11 +589,12 @@ cmdPlaylistAdd id =
     buildWsCmdID "add" id
 
 
-cmdSeek : Float -> String
-cmdSeek seconds =
+cmdSeek : String -> Float -> String
+cmdSeek id seconds =
     Encode.encode 0 <|
         Encode.object
             [ ( "cmd", Encode.string "seek" )
+            , ( "id", Encode.string id )
             , ( "seconds", Encode.float seconds )
             ]
 

--- a/elm/Main.elm
+++ b/elm/Main.elm
@@ -594,7 +594,7 @@ cmdSeek id seconds =
     Encode.encode 0 <|
         Encode.object
             [ ( "cmd", Encode.string "seek" )
-            , ( "id", Encode.string id )
+            , ( "song", Encode.string id )
             , ( "seconds", Encode.float seconds )
             ]
 

--- a/elm/Main.elm
+++ b/elm/Main.elm
@@ -5,7 +5,7 @@ import Dom.Scroll as Scroll
 import FontAwesome
 import Html exposing (Html, button, div, text)
 import Html.Attributes as Attr
-import Html.Events exposing (onClick, onDoubleClick)
+import Html.Events as Events
 import Html.Lazy as Lazy
 import Http
 import Json.Decode as Decode
@@ -230,7 +230,7 @@ viewPlayer model =
                         prettySecs realElapsed ++ "/" ++ prettySecs status.duration
 
                     enbutton c i =
-                        Html.a [ Attr.class "enabled", onClick c ] [ i Color.black 42 ]
+                        Html.a [ Attr.class "enabled", Events.onClick c ] [ i Color.black 42 ]
 
                     disbutton i =
                         Html.a [] [ i Color.darkGrey 42 ]
@@ -293,7 +293,7 @@ viewHeader model =
 
         tab what t =
             Html.a
-                [ onClick <| Show what
+                [ Events.onClick <| Show what
                 , Attr.class <|
                     "tab "
                         ++ (if model.view == what then
@@ -307,7 +307,7 @@ viewHeader model =
     div [ Attr.class "header" ]
         [ Html.a
             [ Attr.class "title"
-            , onClick <| Show Playlist
+            , Events.onClick <| Show Playlist
             , Attr.title "Siren"
             ]
             [ text "[Siren]" ]
@@ -348,13 +348,13 @@ viewPane p =
                         Just <| Attr.class "exp"
                       else
                         Nothing
-                    , Maybe.map onClick e.onClick
+                    , Maybe.map Events.onClick e.onClick
                     , case e.selection of
                         Nothing ->
                             Nothing
 
                         Just p ->
-                            Just <| onDoubleClick <| doubleClick p
+                            Just <| Events.onDoubleClick <| doubleClick p
                     ]
                 )
                 [ text e.title
@@ -389,8 +389,8 @@ viewPane p =
                 []
 
             h :: _ ->
-                [ Html.button [ onClick <| SendWS h ] [ text "add sel to playlist" ]
-                , Html.button [ onClick <| replaceAndPlay h ] [ text "play sel" ]
+                [ Html.button [ Events.onClick <| SendWS h ] [ text "add sel to playlist" ]
+                , Html.button [ Events.onClick <| replaceAndPlay h ] [ text "play sel" ]
                 ]
 
     -- [ Html.a [ Attr.title "add to playlist"] [ icon_add Color.black 24 ]
@@ -436,7 +436,7 @@ viewPlaylist model =
                              else
                                 ""
                             )
-                        , onDoubleClick <| pressPlayID e.id
+                        , Events.onDoubleClick <| pressPlayID e.id
                         ]
                         [ col "track" track
                         , col "title" <| text t.title
@@ -448,7 +448,7 @@ viewPlaylist model =
                 model.playlist
             )
         , div [ Attr.class "commands" ]
-            [ button [ onClick <| pressClear ] [ text "clear playlist" ]
+            [ button [ Events.onClick <| pressClear ] [ text "clear playlist" ]
             ]
         , viewPlayer model
         ]

--- a/elm/Main.elm
+++ b/elm/Main.elm
@@ -269,7 +269,16 @@ viewPlayer model =
                     ++ (if status.state == "pause" || status.state == "play" then
                             [ div [ Attr.class "title" ] [ text song.title ]
                             , div [ Attr.class "artist" ] [ text song.artist ]
-                            , div [ Attr.class "time" ] [ text prettyTime ]
+                            , div [ Attr.class "time" ]
+                                [ Html.input
+                                    [ Attr.type_ "range"
+                                    , Attr.min "0"
+                                    , Attr.max (toString status.duration)
+                                    , Attr.value (toString realElapsed)
+                                    ]
+                                    []
+                                , Html.div [] [ text prettyTime ]
+                                ]
                             ]
                         else
                             []

--- a/elm/Main.elm
+++ b/elm/Main.elm
@@ -336,6 +336,7 @@ viewPlayer model =
                                 , Html.div [] [ text prettyTime ]
                                 ]
                             ]
+
                         else
                             []
                        )
@@ -354,6 +355,7 @@ viewHeader model =
                     "tab "
                         ++ (if model.view == what then
                                 "curr"
+
                             else
                                 ""
                            )
@@ -402,6 +404,7 @@ viewPane p =
                 (List.filterMap identity
                     [ if p.current == Just e.id then
                         Just <| Attr.class "exp"
+
                       else
                         Nothing
                     , Maybe.map Events.onClick e.onClick
@@ -480,8 +483,10 @@ viewPlaylist model =
                         track =
                             if current && Maybe.map .state model.status == Just "play" then
                                 icon_play Color.black 16
+
                             else if current && Maybe.map .state model.status == Just "pause" then
                                 icon_pause Color.black 16
+
                             else
                                 text t.track
                     in
@@ -489,6 +494,7 @@ viewPlaylist model =
                         [ Attr.class
                             (if current then
                                 "current"
+
                              else
                                 ""
                             )

--- a/elm/Mpd.elm
+++ b/elm/Mpd.elm
@@ -147,6 +147,7 @@ decodeFloatString =
             (\s ->
                 if s == "" then
                     Decode.succeed 0
+
                 else
                     case Decode.decodeString Decode.float s of
                         Ok r ->

--- a/elm/Pane.elm
+++ b/elm/Pane.elm
@@ -54,6 +54,7 @@ addPane panes after new =
         p :: tail ->
             if p.id == after then
                 { p | current = Just new.id } :: [ new ]
+
             else
                 p :: addPane tail after new
 
@@ -67,5 +68,6 @@ setBody body paneid panes =
         p :: tail ->
             if p.id == paneid then
                 { p | body = body } :: tail
+
             else
                 p :: setBody body paneid tail

--- a/siren/websocket.go
+++ b/siren/websocket.go
@@ -24,13 +24,14 @@ type WSMsg struct {
 
 // from the client to us. Cmd is always filled.
 type WSCmd struct {
-	Cmd    string `json:"cmd"`
-	ID     string `json:"id"` // will be used as WSMsg.ID
-	What   string `json:"what"`
-	Artist string `json:"artist"`
-	Album  string `json:"album"`
-	Track  string `json:"track"`
-	File   string `json:"file"`
+	Cmd     string  `json:"cmd"`
+	ID      string  `json:"id"` // will be used as WSMsg.ID
+	What    string  `json:"what"`
+	Artist  string  `json:"artist"`
+	Album   string  `json:"album"`
+	Track   string  `json:"track"`
+	File    string  `json:"file"`
+	Seconds float64 `json:"seconds"`
 }
 
 func websocketHandler(c *MPD) func(http.ResponseWriter, *http.Request) {
@@ -185,6 +186,9 @@ var handlers = map[string]func(*MPD, chan WSMsg, WSCmd) error{
 			Msg:  ls[0],
 		}
 		return nil
+	},
+	"seek": func(c *MPD, _ chan WSMsg, cmd WSCmd) error {
+		return c.Write(fmt.Sprintf("seekcur %f", cmd.Seconds))
 	},
 }
 

--- a/siren/websocket.go
+++ b/siren/websocket.go
@@ -188,7 +188,7 @@ var handlers = map[string]func(*MPD, chan WSMsg, WSCmd) error{
 		return nil
 	},
 	"seek": func(c *MPD, _ chan WSMsg, cmd WSCmd) error {
-		return c.Write(fmt.Sprintf("seekcur %f", cmd.Seconds))
+		return c.Write(fmt.Sprintf("seekid %s %d", cmd.ID, int(cmd.Seconds)))
 	},
 }
 

--- a/siren/websocket.go
+++ b/siren/websocket.go
@@ -32,6 +32,7 @@ type WSCmd struct {
 	Track   string  `json:"track"`
 	File    string  `json:"file"`
 	Seconds float64 `json:"seconds"`
+	Song    string  `json:"song"`
 }
 
 func websocketHandler(c *MPD) func(http.ResponseWriter, *http.Request) {
@@ -188,7 +189,7 @@ var handlers = map[string]func(*MPD, chan WSMsg, WSCmd) error{
 		return nil
 	},
 	"seek": func(c *MPD, _ chan WSMsg, cmd WSCmd) error {
-		return c.Write(fmt.Sprintf("seekid %s %d", cmd.ID, int(cmd.Seconds)))
+		return c.Write(fmt.Sprintf("seekid %s %d", cmd.Song, int(cmd.Seconds)))
 	},
 }
 


### PR DESCRIPTION
This adds a time slider input range control. Making it nicely usable will be a bit more work.

To hook into the change event, the following would work:

```
    ...
    , Html.Events.on "change" (Decode.map (SendWS seekTo) targetValueAsNumber)
    ]

targetValueAsNumber : Decode.Decoder Float
targetValueAsNumber =
    Decode.at [ "target", "valueAsNumber" ] Decode.float
```

But that will require doing something to disable model->value updates while the slider is being dragged.