### PR TITLE
make the arrows nicer

### DIFF
--- a/docroot/s/siren.css
+++ b/docroot/s/siren.css
@@ -149,9 +149,24 @@ body {
 .pane > div:nth-child(odd):hover {
     background-color: #ccc;
 }
-.pane .exp:after {
-    float: right;
-    content: ">";
+.pane div div {
+    line-height: 1.2;
+    margin-top: auto;
+    margin-bottom: auto;
+}
+.pane .arrow {
+    display: none;
+}
+.pane .exp .arrow {
+    display: block;
+}
+.pane .exp {
+    display: grid;
+    grid-template-columns: 1fr;
+    grid-auto-columns: 10px;
+    grid-auto-flow: column;
+    margin-top: auto;
+    margin-bottom: auto;
 }
 
 button {

--- a/elm/Main.elm
+++ b/elm/Main.elm
@@ -468,7 +468,8 @@ viewPane p =
                             Just <| Events.onDoubleClick <| doubleClick p
                     ]
                 )
-                [ text e.title
+                [ div [] [ text e.title ]
+                , div [ Attr.class "arrow" ] [ text "▸" ]
                 ]
 
         viewBody : Pane.Body Msg -> List (Html Msg)


### PR DESCRIPTION
not really sure the `display: none` is a good idea, it does cause a reflow when you select an entry that just fills a box