### PR TITLE
Albumartist

### DIFF
--- a/docroot/s/siren.css
+++ b/docroot/s/siren.css
@@ -33,7 +33,7 @@ body {
 nav {
     background-color: #3F51B5;
     display: grid;
-    grid-template-columns: max-content 1fr repeat(3, max-content) 1fr max-content;
+    grid-template-columns: max-content 1fr repeat(4, max-content) 1fr max-content;
     grid-gap: 50px;
     padding: 0 50px;
     box-shadow: 0 3px 3px 0 #ccc;

--- a/docroot/s/siren.css
+++ b/docroot/s/siren.css
@@ -33,7 +33,7 @@ body {
 nav {
     background-color: #3F51B5;
     display: grid;
-    grid-template-columns: max-content 1fr repeat(4, max-content) 1fr max-content;
+    grid-template-columns: max-content 1fr repeat(3, max-content) 1fr max-content;
     grid-gap: 50px;
     padding: 0 50px;
     box-shadow: 0 3px 3px 0 #ccc;

--- a/elm/Main.elm
+++ b/elm/Main.elm
@@ -490,7 +490,7 @@ viewHeader model =
         count =
             " (" ++ (toString <| List.length model.playlist) ++ ")"
 
-        tab what t =
+        tab what t title =
             Html.a
                 [ Events.onClick <| Show what
                 , Attr.class <|
@@ -501,6 +501,7 @@ viewHeader model =
                             else
                                 "inactive"
                            )
+                , Attr.title title
                 ]
                 [ text t ]
 
@@ -531,10 +532,11 @@ viewHeader model =
             ]
             [ text "Siren!" ]
         , Html.span [] []
-        , tab Playlist <| "Playlist" ++ count
-        , tab FileBrowser "Files"
-        , tab (ArtistBrowser Artist) "Artists"
-        , tab (ArtistBrowser Albumartist) "Albumartists"
+        , tab Playlist ("Playlist" ++ count) "Show playlist"
+        , tab FileBrowser "Files" "Browse the filesystem"
+        , case artistMode model.config of
+            Artist -> tab (ArtistBrowser Artist) "Artists" "Browse artists"
+            Albumartist -> tab (ArtistBrowser Albumartist) "Artists" "Browse AlbumArtists"
         , Html.span [] []
         , Html.a
             [ Attr.class <| "status " ++ cssClass

--- a/siren/main.go
+++ b/siren/main.go
@@ -10,11 +10,12 @@ import (
 )
 
 var (
-	version     = "master"
-	mpdURL      = flag.String("mpd", "", "MPD address. order of options: this flag, MPD_HOST:MPD_PORT, localhost:6600. port is optional")
-	listen      = flag.String("listen", ":6601", "http listen address")
-	static      = flag.String("docroot", "", "for development: use directory as docroot, not the build-in files")
-	showVersion = flag.Bool("version", false, "show version and exit")
+	version        = "master"
+	mpdURL         = flag.String("mpd", "", "MPD address. order of options: this flag, MPD_HOST:MPD_PORT, localhost:6600. port is optional")
+	listen         = flag.String("listen", ":6601", "http listen address")
+	static         = flag.String("docroot", "", "for development: use directory as docroot, not the build-in files")
+	useAlbumartist = flag.Bool("albumartist", true, "use albumartist, not artist")
+	showVersion    = flag.Bool("version", false, "show version and exit")
 )
 
 func main() {
@@ -26,7 +27,7 @@ func main() {
 	}
 
 	u := url(*mpdURL)
-	c, err := NewMPD(u)
+	c, err := NewMPD(u, *useAlbumartist)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/siren/main.go
+++ b/siren/main.go
@@ -27,7 +27,11 @@ func main() {
 	}
 
 	u := url(*mpdURL)
-	c, err := NewMPD(u, *useAlbumartist)
+	mode := ModeArtist
+	if *useAlbumartist {
+		mode = ModeAlbumartist
+	}
+	c, err := NewMPD(u, mode)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/siren/mpd.go
+++ b/siren/mpd.go
@@ -14,7 +14,8 @@ import (
 )
 
 type MPD struct {
-	url string
+	url            string
+	useAlbumartist bool
 }
 
 type conn struct {
@@ -22,9 +23,10 @@ type conn struct {
 	r *bufio.Reader
 }
 
-func NewMPD(url string) (*MPD, error) {
+func NewMPD(url string, albumartist bool) (*MPD, error) {
 	m := &MPD{
-		url: url,
+		url:            url,
+		useAlbumartist: albumartist,
 	}
 	return m, nil
 }

--- a/siren/websocket.go
+++ b/siren/websocket.go
@@ -49,6 +49,16 @@ func websocketHandler(c *MPD) func(http.ResponseWriter, *http.Request) {
 			})
 		}
 
+		// init client state
+		config := WSConfig{
+			UseAlbumartist: c.useAlbumartist,
+			MpdHost:        c.url,
+		}
+		if err := writeMsg(config); err != nil {
+			log.Printf("writeMsg: %s", err)
+			return
+		}
+
 		go func(ctx context.Context, conn *websocket.Conn) {
 			tick := time.NewTicker(55 * time.Second)
 			defer tick.Stop()
@@ -131,6 +141,13 @@ func websocketHandler(c *MPD) func(http.ResponseWriter, *http.Request) {
 		}
 	}
 }
+
+type WSConfig struct {
+	UseAlbumartist bool   `edn:"usealbumartist"`
+	MpdHost        string `edn:"mpdhost"`
+}
+
+func (w WSConfig) Type() string { return "config" }
 
 type WSInodes struct {
 	ID     string  `edn:"id"`


### PR DESCRIPTION
The backend sets whether 'album' or 'albumartist' is used (CLI flag). The frontend gets this flag via a new 'Config' message so it can use the correct column in the playlist tab (the frontend now also gets the MPD URL, since why not).

Currently there is a new additional tab 'AlbumArtist' in the GUI. The idea is that this goes back to three tabs ("Playlist | Files | Artists") and the frontend shows either the artists or the albumartists tree when the "artist" tab is selected, depending on the config.

The frontend now keeps track of three view trees: files, artists, and albumartist. This way things will work nicely when the backend is restared with a new config.

The two commits are likely best read standalone.